### PR TITLE
Change Graph.Get to compare Terms using Equals

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -209,7 +209,7 @@ func (graph *Graph) GetAll(subject Term, predicate Term) (objects []Term) {
 // found.
 func (graph *Graph) Get(subject Term, predicate Term) (object Term) {
 	for triple := range graph.IterTriples() {
-		if triple.Subject == subject && triple.Predicate == predicate {
+		if triple.Subject.Equals(subject) && triple.Predicate.Equals(predicate) {
 			return triple.Object
 		}
 	}


### PR DESCRIPTION
Comparing terms with "==" generates wrong results if two different Terms with the same value are used.
